### PR TITLE
feat(valid-id-rule): validate id with curly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eduzz/eslint-config",
   "private": false,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "eduzz",
     "eslint"


### PR DESCRIPTION
This pull request includes updates to the `@eduzz/eslint-config` package and enhancements to the `validId` ESLint rule. The changes improve functionality by introducing a utility function for extracting attribute values, ensuring proper handling of whitespace, and refining the validation logic.

### Package updates:

* Updated the version of `@eduzz/eslint-config` from `2.5.0` to `2.5.1` in `package.json`.

### Enhancements to `validId` rule:

* Added a new utility function, `extractAttributeValue`, to handle different node value types (`Literal`, `JSXExpressionContainer`, and `TemplateLiteral`) for extracting attribute values.
* Improved whitespace handling by adding `.trim()` checks to ensure IDs with leading or trailing spaces are flagged as invalid. This applies to `Literal`, `JSXExpressionContainer`, and `TemplateLiteral` node types. [[1]](diffhunk://#diff-fcb505233f8f198f22ac79d5b17a4e835e03a27c5e067e7e41d42100ff554c9dL30-R46) [[2]](diffhunk://#diff-fcb505233f8f198f22ac79d5b17a4e835e03a27c5e067e7e41d42100ff554c9dL44-R60) [[3]](diffhunk://#diff-fcb505233f8f198f22ac79d5b17a4e835e03a27c5e067e7e41d42100ff554c9dL55-R71)
* Refactored the `isIdMalformed` check to use the extracted value from the new `extractAttributeValue` function, ensuring consistent validation across all node types.
