### PR TITLE
Feature cpi 2041

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eduzz/eslint-config",
   "private": false,
-  "version": "2.5.3",
+  "version": "2.5.2",
   "keywords": [
     "eduzz",
     "eslint"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eduzz/eslint-config",
   "private": false,
-  "version": "2.5.1",
+  "version": "2.5.3",
   "keywords": [
     "eduzz",
     "eslint"

--- a/rules/validId.js
+++ b/rules/validId.js
@@ -3,6 +3,10 @@ const isIdMalformed = text => {
 };
 
 const extractAttributeValue = node => {
+  if (!node.value || !node.value.type) {
+    return '';
+  }
+
   if (node.value.type === 'Literal') {
     return node.value.value;
   }
@@ -12,7 +16,7 @@ const extractAttributeValue = node => {
   }
 
   if (node.value.expression.type === 'TemplateLiteral') {
-    return node.value.expression.expressions.map(expr => expr.value).join('');
+    return node.value.expression.quasis.map(({ value }) => value.cooked).join('');
   }
 
   return '';
@@ -56,9 +60,9 @@ module.exports = {
         const isJsxExpressionTemplateLiteralIdEmpty =
           node.value.type === 'JSXExpressionContainer' &&
           node.value.expression.type === 'TemplateLiteral' &&
-          node.value.expression.expressions.length === 1 &&
-          !Boolean(node.value.expression.expressions[0].value.trim()) &&
-          'value' in node.value.expression.expressions[0];
+          node.value.expression.quasis.length === 1 &&
+          'value' in node.value.expression.quasis[0] &&
+          !Boolean(node.value.expression.quasis[0].value.cooked.trim());
 
         if (isJsxExpressionTemplateLiteralIdEmpty) {
           context.report({
@@ -79,6 +83,7 @@ module.exports = {
         }
 
         const value = extractAttributeValue(node);
+        console.log('value ->', value);
 
         if (isIdMalformed(value)) {
           context.report({

--- a/rules/validId.js
+++ b/rules/validId.js
@@ -83,7 +83,6 @@ module.exports = {
         }
 
         const value = extractAttributeValue(node);
-        console.log('value ->', value);
 
         if (isIdMalformed(value)) {
           context.report({


### PR DESCRIPTION
This pull request includes a version bump for the `@eduzz/eslint-config` package and updates to the `validId` rule to improve its handling of `TemplateLiteral` nodes and ensure robustness against malformed inputs.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `2.5.1` to `2.5.2`.

### Improvements to `validId` Rule:
* `rules/validId.js`:
  - Enhanced `extractAttributeValue` to handle cases where `node.value` or `node.value.type` is undefined, returning an empty string in such cases.
  - Updated the handling of `TemplateLiteral` nodes in `extractAttributeValue` to use `quasis` instead of `expressions` for extracting values, ensuring accurate string reconstruction.
  - Refined the check for empty `TemplateLiteral` IDs by replacing `expressions` with `quasis` and using `value.cooked` for trimmed value validation.