### PR TITLE
fix(valid-id-rule): add validation for identifier as id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eduzz/eslint-config",
   "private": false,
-  "version": "2.5.2",
+  "version": "2.5.3",
   "keywords": [
     "eduzz",
     "eslint"

--- a/rules/validId.js
+++ b/rules/validId.js
@@ -44,6 +44,14 @@ module.exports = {
           return;
         }
 
+        const isJsxExpressionValueVariable =
+          node.value.type === 'JSXExpressionContainer' &&
+          (node.value.expression.type === 'Identifier' || node.value.expression.type === 'MemberExpression');
+
+        if (isJsxExpressionValueVariable) {
+          return;
+        }
+
         const isJsxExpressionLiteralIdEmpty =
           node.value.type === 'JSXExpressionContainer' &&
           node.value.expression.type === 'Literal' &&


### PR DESCRIPTION
This pull request includes a version bump for the package and an enhancement to the `validId` rule in the ESLint configuration. The changes ensure better handling of JSX expression values in the `validId` rule.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `2.5.2` to `2.5.3`.

### Rule Enhancement:
* [`rules/validId.js`](diffhunk://#diff-fcb505233f8f198f22ac79d5b17a4e835e03a27c5e067e7e41d42100ff554c9dR47-R54): Enhanced the `validId` rule to skip validation for JSX attributes where the value is a variable (`Identifier` or `MemberExpression`) wrapped in a `JSXExpressionContainer`. This prevents unnecessary validation errors for such cases.

Solve cases like

`id={coolName}` and `id={cool.name}`
