### PR TITLE
fix(id-rule): remove id with object as value from validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eduzz/eslint-config",
   "private": false,
-  "version": "2.5.3",
+  "version": "2.5.4",
   "keywords": [
     "eduzz",
     "eslint"

--- a/rules/requiredId.js
+++ b/rules/requiredId.js
@@ -21,6 +21,8 @@ const isDefaultImportSourceSupported = source =>
     'antd/lib/checkbox/Checkbox'
   ].includes(source);
 
+const excludeNestedComponentsNameList = [['Checkbox', 'Group']];
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -82,6 +84,13 @@ module.exports = {
         }
 
         if (node.name.type === 'JSXMemberExpression' && !components.includes(node.name.object.name)) {
+          return;
+        }
+
+        if (
+          node.name.type === 'JSXMemberExpression' &&
+          excludeNestedComponentsNameList.includes([node.name.object.name, node.name.property.name])
+        ) {
           return;
         }
 

--- a/rules/validId.js
+++ b/rules/validId.js
@@ -46,7 +46,10 @@ module.exports = {
 
         const isJsxExpressionValueVariable =
           node.value.type === 'JSXExpressionContainer' &&
-          (node.value.expression.type === 'Identifier' || node.value.expression.type === 'MemberExpression');
+          (node.value.expression.type === 'Identifier' ||
+            node.value.expression.type === 'MemberExpression' ||
+            node.value.expression.type === 'ObjectExpression' ||
+            node.value.expression.type === 'ArrayExpression');
 
         if (isJsxExpressionValueVariable) {
           return;


### PR DESCRIPTION
This pull request includes a version bump in `package.json` and an enhancement to the `validId` rule in `rules/validId.js`. The changes refine the handling of JSX expressions and improve compatibility with additional expression types.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `2.5.3` to `2.5.4`.

### Rule enhancement:
* [`rules/validId.js`](diffhunk://#diff-fcb505233f8f198f22ac79d5b17a4e835e03a27c5e067e7e41d42100ff554c9dL49-R52): Enhanced the `validId` rule to support additional JSX expression types (`ObjectExpression` and `ArrayExpression`) in the `isJsxExpressionValueVariable` check.

Solved for this cases:
<img width="332" height="238" alt="Screenshot 2025-07-10 at 09 56 10" src="https://github.com/user-attachments/assets/40b0ead7-5140-4063-9a3e-0f13c5455e92" />
