### PR TITLE
fix(exclude-list): add another way to validate exclude list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eduzz/eslint-config",
   "private": false,
-  "version": "2.5.4",
+  "version": "2.5.5",
   "keywords": [
     "eduzz",
     "eslint"

--- a/rules/requiredId.js
+++ b/rules/requiredId.js
@@ -89,7 +89,9 @@ module.exports = {
 
         if (
           node.name.type === 'JSXMemberExpression' &&
-          excludeNestedComponentsNameList.includes([node.name.object.name, node.name.property.name])
+          excludeNestedComponentsNameList.some(
+            ([parent, children]) => parent === node.name.object.name && children === node.name.property.name
+          )
         ) {
           return;
         }


### PR DESCRIPTION

This pull request includes two changes: a version bump in the `package.json` file and an improvement to the logic in the `rules/requiredId.js` file.

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the package version from `2.5.4` to `2.5.5`.

### Logic improvement:
* [`rules/requiredId.js`](diffhunk://#diff-e5e5431f7e189290661327e74cc20f06624f8df9209f833a9eeebd6bcf1e4411L92-R94): Enhanced the `excludeNestedComponentsNameList` check by replacing `includes` with `some` for better readability and functionality when comparing nested component names.